### PR TITLE
Endless mode / Continuous read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Content of route files can be repeated endlessly via the `--endless` flag
 
 ## [1.1.0] - 2015-12-18
 

--- a/config/options.go
+++ b/config/options.go
@@ -5,6 +5,7 @@ type Options struct {
 	Host             string
 	File             string
 	OutputFilename   string
+	RunEndless       bool
 }
 
 func newDefaultOptions() Options {

--- a/config/parser.go
+++ b/config/parser.go
@@ -46,6 +46,8 @@ func parseFlag(options Options, arguments ...string) (Options, error) {
 		return parseHostnameArgument(options, arguments...)
 	} else if isOutFlag(flag) {
 		return parseOutputFileArgument(options, arguments...)
+	} else if isEndlessFlag(flag) {
+		return parseEndlessArgument(options, arguments...)
 	}
 
 	return options, errors.New("Invalid argument: " + flag)
@@ -74,6 +76,10 @@ func isHostFlag(argument string) bool {
 
 func isOutFlag(argument string) bool {
 	return argument == "-o" || argument == "--out"
+}
+
+func isEndlessFlag(argument string) bool {
+	return argument == "-e" || argument == "--endless"
 }
 
 func fileArgumentIsAllowed(options Options) bool {
@@ -122,4 +128,10 @@ func parseOutputFileArgument(options Options, arguments ...string) (Options, err
 	options.OutputFilename = arguments[1]
 
 	return parseArguments(options, arguments[2:]...)
+}
+
+func parseEndlessArgument(options Options, arguments ...string) (Options, error) {
+	options.RunEndless = true
+
+	return parseArguments(options, arguments[1:]...)
 }

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -93,7 +93,6 @@ var _ = Describe("Config - Parser", func() {
 
 	Context("--out flag", func() {
 		It("parses the filename (short flag)", func() {
-
 			options, _ := config.Parse("-o", "output-filename")
 
 			Expect(options.OutputFilename).To(Equal("output-filename"))
@@ -113,23 +112,41 @@ var _ = Describe("Config - Parser", func() {
 		})
 	})
 
+	Context("--endless flag", func() {
+		It("parses the short flag", func() {
+			options, _ := config.Parse("-e")
+
+			Expect(options.RunEndless).To(BeTrue())
+		})
+
+		It("parses the long flag", func() {
+			options, _ := config.Parse("--endless")
+
+			Expect(options.RunEndless).To(BeTrue())
+		})
+	})
+
 	Context("all arguments", func() {
 		It("parses all options", func() {
-			options, err := config.Parse("-t", "42", "-h", "http://hostname", "filename")
+			options, err := config.Parse("-t", "42", "-h", "http://hostname", "-o", "output", "filename", "-e")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options.Host).To(Equal("http://hostname"))
 			Expect(options.NumberOfRoutines).To(Equal(42))
 			Expect(options.File).To(Equal("filename"))
+			Expect(options.OutputFilename).To(Equal("output"))
+			Expect(options.RunEndless).To(BeTrue())
 		})
 
 		It("doesn't care about the order of the filename and flags", func() {
-			options, err := config.Parse("filename", "-t", "42", "-h", "http://hostname")
+			options, err := config.Parse("-e", "filename", "-t", "42", "-h", "http://hostname", "-o", "output")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options.Host).To(Equal("http://hostname"))
 			Expect(options.NumberOfRoutines).To(Equal(42))
 			Expect(options.File).To(Equal("filename"))
+			Expect(options.OutputFilename).To(Equal("output"))
+			Expect(options.RunEndless).To(BeTrue())
 		})
 	})
 })

--- a/files/endless_file.go
+++ b/files/endless_file.go
@@ -1,0 +1,18 @@
+package files
+
+import "io"
+
+type EndlessFile struct {
+	File
+}
+
+func (file EndlessFile) Read(b []byte) (int, error) {
+	data, e := file.File.Read(b)
+
+	if e == io.EOF {
+		file.File.Seek(0, 0)
+		data, e = file.File.Read(b)
+	}
+
+	return data, e
+}

--- a/files/endless_file_test.go
+++ b/files/endless_file_test.go
@@ -1,0 +1,31 @@
+package files_test
+
+import (
+	"bufio"
+	"github.com/christophgockel/goony/files"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Endless File", func() {
+	var scanner *bufio.Scanner
+
+	readLine := func() string {
+		scanner.Scan()
+		return scanner.Text()
+	}
+
+	It("continously reads file contents", func() {
+		file := fakeFile{}
+		file.AddLine("line 1")
+		file.AddLine("line 2")
+
+		endlessFile := files.EndlessFile{file}
+		scanner = bufio.NewScanner(endlessFile)
+
+		Expect(readLine()).To(Equal("line 1"))
+		Expect(readLine()).To(Equal("line 2"))
+		Expect(readLine()).To(Equal("line 1"))
+		Expect(readLine()).To(Equal("line 2"))
+	})
+})

--- a/files/fake_file_system_test.go
+++ b/files/fake_file_system_test.go
@@ -1,6 +1,7 @@
 package files_test
 
 import (
+	"bytes"
 	"github.com/christophgockel/goony/files"
 	"os"
 )
@@ -15,10 +16,6 @@ type aFakeFileSystem struct {
 
 	openHasBeenCalled   bool
 	createHasBeenCalled bool
-}
-
-type fakeFile struct {
-	files.File
 }
 
 func (fs *aFakeFileSystem) Open(name string) (files.File, error) {
@@ -72,4 +69,35 @@ func fileIsWritable() bool {
 
 func fileIsReadable() bool {
 	return fakeFilesystem.openHasBeenCalled
+}
+
+type fakeFile struct {
+	files.File
+
+	lines   []string
+	content *bytes.Buffer
+}
+
+func (file fakeFile) Write(p []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (file fakeFile) Read(p []byte) (n int, err error) {
+	return file.content.Read(p)
+}
+
+func (file fakeFile) Seek(offset int64, whence int) (int64, error) {
+	for _, line := range file.lines {
+		file.AddLine(line)
+	}
+
+	return 0, nil
+}
+
+func (file *fakeFile) AddLine(line string) {
+	if file.content == nil {
+		file.content = new(bytes.Buffer)
+	}
+	file.lines = append(file.lines, line)
+	file.content.WriteString(line + "\n")
 }

--- a/files/file.go
+++ b/files/file.go
@@ -1,0 +1,10 @@
+package files
+
+import "io"
+
+type File interface {
+	io.Reader
+	io.Writer
+	io.Seeker
+	io.Closer
+}

--- a/files/file_system.go
+++ b/files/file_system.go
@@ -1,20 +1,12 @@
 package files
 
-import (
-	"io"
-	"os"
-)
+import "os"
 
 var Filesystem TheFileSystem = realFilesystem{}
 
 type TheFileSystem interface {
 	Create(name string) (File, error)
 	Open(name string) (File, error)
-}
-
-type File interface {
-	io.Reader
-	io.Writer
 }
 
 type realFilesystem struct{}

--- a/files/stream.go
+++ b/files/stream.go
@@ -1,16 +1,21 @@
 package files
 
-import (
-	"bufio"
-	"io"
-)
+import "bufio"
 
-func StreamContent(input io.Reader, channel chan string) {
-	scanner := bufio.NewScanner(input)
+func StreamContent(file File, lines chan string, stop chan bool) {
+	scanner := bufio.NewScanner(file)
 
-	for scanner.Scan() {
-		channel <- scanner.Text()
+	for {
+		select {
+		case <-stop:
+			close(lines)
+			return
+		default:
+			if scanner.Scan() {
+				lines <- scanner.Text()
+			} else {
+				stop <- true
+			}
+		}
 	}
-
-	close(channel)
 }

--- a/signals/signals_suite_test.go
+++ b/signals/signals_suite_test.go
@@ -1,0 +1,12 @@
+package signals_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestFiles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Signals Suite")
+}

--- a/signals/waiting.go
+++ b/signals/waiting.go
@@ -1,0 +1,8 @@
+package signals
+
+import "os"
+
+func WaitForSignal(signals chan os.Signal, trues chan bool) {
+	<-signals
+	trues <- true
+}

--- a/signals/waiting_test.go
+++ b/signals/waiting_test.go
@@ -1,0 +1,20 @@
+package signals_test
+
+import (
+	"github.com/christophgockel/goony/signals"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"os"
+)
+
+var _ = Describe("Waiting for a signal", func() {
+	It("emits a true value when a signal is read", func() {
+		signalChannel := make(chan os.Signal)
+		outputChannel := make(chan bool)
+
+		go signals.WaitForSignal(signalChannel, outputChannel)
+		signalChannel <- os.Interrupt
+
+		Expect(<-outputChannel).To(BeTrue())
+	})
+})


### PR DESCRIPTION
First stab at endless mode.
Not 100% happy with `StreamContentForever()` but reading from more than one channel asks for a `select`.
I'd like to simplify it more but can't think of a good way at the moment.
One thing I thought of is completely ignoring the "graceful" termination that is currently implemented in this PR.
As it is right now, a Ctrl+C is caught and then a message is passed to the streaming function to stop streaming (via the `stop` channel).
From there on all remaining worker routines stop their work and eventually `main` is exited normally.

I was wondering if that is actually needed and if it would be feasible to ignore it and just have Ctrl+C terminate the program in whichever state it currently is.
