### PR TITLE
Colored output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Colored results can be enabled via a `--color` flag.
+  - The request status and HTTP status code are colored depending on whether they were successful or not.
+
 
 ## [1.2.0] - 2016-01-22
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The easiest way at the moment: `go get github.com/christophgockel/goony`
 
 ## Usage
 
-> `goony [-t|--threads n] [-h|--host http://target-host] [-o|--out filename] [-e|--endless] routes-file`
+> `goony [-t|--threads n] [-h|--host http://target-host] [-o|--out filename] [-e|--endless] [-c|--color] routes-file`
 
 Goony has to be called with at least the route file as its argument.
 Additionally to that, there are flags to configure the number of threads (goroutines), or specify the target host, etc.
@@ -37,6 +37,8 @@ Additionally to that, there are flags to configure the number of threads (gorout
   - Writes CSV output to file `report.csv`
 - `goony --endless routes.txt`
   - Re-runs all routes from `routes.txt` continuously until aborted with Ctrl+C.
+- `goony --color routes.txt`
+  - Goony's output has colored status codes.
 - `goony --help`
   - Prints a usage help with examples.
 

--- a/config/checker.go
+++ b/config/checker.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"errors"
+)
+
+func Check(options Options) error {
+	if options.UsageHelp {
+		return nil
+	}
+
+	if options.File == "" {
+		return errors.New("Filename is missing")
+	} else if options.UseColors && options.OutputFilename != "" {
+		return errors.New("Colored output not available in conjunction with an output file")
+	}
+
+	return nil
+}

--- a/config/checker_test.go
+++ b/config/checker_test.go
@@ -1,0 +1,30 @@
+package config_test
+
+import (
+	"github.com/christophgockel/goony/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config - Checker", func() {
+	It("returns an error if no filename is specified", func() {
+		options := config.Options{}
+		err := config.Check(options)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("Filename is missing"))
+	})
+
+	It("returns an error if colors are used with an output file", func() {
+		options := config.Options{
+			File:           "routes-file",
+			UseColors:      true,
+			OutputFilename: "output-file",
+		}
+
+		err := config.Check(options)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("Colored output not available in conjunction with an output file"))
+	})
+})

--- a/config/options.go
+++ b/config/options.go
@@ -11,6 +11,7 @@ type Options struct {
 	File             string
 	OutputFilename   string
 	RunEndless       bool
+	UseColors        bool
 }
 
 func newDefaultOptions() Options {

--- a/config/parse_and_check.go
+++ b/config/parse_and_check.go
@@ -1,0 +1,11 @@
+package config
+
+func ParseAndCheck(arguments ...string) (Options, error) {
+	options, err := Parse(arguments...)
+
+	if err == nil {
+		err = Check(options)
+	}
+
+	return options, err
+}

--- a/config/parse_and_check_test.go
+++ b/config/parse_and_check_test.go
@@ -1,0 +1,31 @@
+package config_test
+
+import (
+	"github.com/christophgockel/goony/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config - ParseAndCheck", func() {
+	It("parses and verifies configuration options", func() {
+		options, err := config.ParseAndCheck("-h", "http://host.name", "filename")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(options.Host).To(Equal("http://host.name"))
+		Expect(options.File).To(Equal("filename"))
+	})
+
+	It("returns errors of argument parsing", func() {
+		_, err := config.ParseAndCheck("-h")
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("Missing hostname"))
+	})
+
+	It("returns errors of option checking", func() {
+		_, err := config.ParseAndCheck()
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("Filename is missing"))
+	})
+})

--- a/config/parser.go
+++ b/config/parser.go
@@ -50,6 +50,8 @@ func parseFlag(options Options, arguments ...string) (Options, error) {
 		return parseEndlessArgument(options, arguments...)
 	} else if isHelpFlag(flag) {
 		return parseHelpArgument(options, arguments...)
+	} else if isColorFlag(flag) {
+		return parseColorArgument(options, arguments...)
 	}
 
 	return options, errors.New("Invalid argument: " + flag)
@@ -86,6 +88,10 @@ func isEndlessFlag(argument string) bool {
 
 func isHelpFlag(argument string) bool {
 	return argument == "--help"
+}
+
+func isColorFlag(argument string) bool {
+	return argument == "-c" || argument == "--color"
 }
 
 func fileArgumentIsAllowed(options Options) bool {
@@ -147,4 +153,10 @@ func parseHelpArgument(options Options, arguments ...string) (Options, error) {
 	resettedOptions.UsageHelp = true
 
 	return parseArguments(resettedOptions, arguments[0:0]...)
+}
+
+func parseColorArgument(options Options, arguments ...string) (Options, error) {
+	options.UseColors = true
+
+	return parseArguments(options, arguments[1:]...)
 }

--- a/config/parser.go
+++ b/config/parser.go
@@ -7,20 +7,7 @@ import (
 )
 
 func Parse(arguments ...string) (Options, error) {
-	var err error
-	options := newDefaultOptions()
-
-	options, err = parseArguments(options, arguments...)
-
-	if err != nil || options.UsageHelp {
-		return options, err
-	}
-
-	if options.File == "" {
-		return options, errors.New("Filename is missing")
-	}
-
-	return options, err
+	return parseArguments(newDefaultOptions(), arguments...)
 }
 
 func parseArguments(options Options, arguments ...string) (Options, error) {

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -7,13 +7,6 @@ import (
 )
 
 var _ = Describe("Config - Parser", func() {
-	It("returns an error if no arguments are given", func() {
-		_, err := config.Parse()
-
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("Filename is missing"))
-	})
-
 	It("returns an error for mistyped flag", func() {
 		_, err := config.Parse("-t800")
 
@@ -22,13 +15,6 @@ var _ = Describe("Config - Parser", func() {
 	})
 
 	Context("filename argument", func() {
-		It("returns an error if no file has been specified", func() {
-			_, err := config.Parse("-h", "host.name")
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(Equal("Filename is missing"))
-		})
-
 		It("parses the filename", func() {
 			options, _ := config.Parse("filename")
 

--- a/config/parser_test.go
+++ b/config/parser_test.go
@@ -143,9 +143,23 @@ var _ = Describe("Config - Parser", func() {
 		})
 	})
 
+	Context("--color flag", func() {
+		It("parses short flag", func() {
+			options, _ := config.Parse("-c")
+
+			Expect(options.UseColors).To(BeTrue())
+		})
+
+		It("parses the long flag", func() {
+			options, _ := config.Parse("--color")
+
+			Expect(options.UseColors).To(BeTrue())
+		})
+	})
+
 	Context("all arguments", func() {
 		It("parses all options", func() {
-			options, err := config.Parse("-t", "42", "-h", "http://hostname", "-o", "output", "filename", "-e")
+			options, err := config.Parse("-t", "42", "-h", "http://hostname", "-o", "output", "-e", "-c", "filename")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options.Host).To(Equal("http://hostname"))
@@ -153,10 +167,11 @@ var _ = Describe("Config - Parser", func() {
 			Expect(options.File).To(Equal("filename"))
 			Expect(options.OutputFilename).To(Equal("output"))
 			Expect(options.RunEndless).To(BeTrue())
+			Expect(options.UseColors).To(BeTrue())
 		})
 
 		It("doesn't care about the order of the filename and flags", func() {
-			options, err := config.Parse("-e", "filename", "-t", "42", "-h", "http://hostname", "-o", "output")
+			options, err := config.Parse("-e", "-c", "filename", "-t", "42", "-h", "http://hostname", "-o", "output")
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(options.Host).To(Equal("http://hostname"))
@@ -164,6 +179,7 @@ var _ = Describe("Config - Parser", func() {
 			Expect(options.File).To(Equal("filename"))
 			Expect(options.OutputFilename).To(Equal("output"))
 			Expect(options.RunEndless).To(BeTrue())
+			Expect(options.UseColors).To(BeTrue())
 		})
 	})
 })

--- a/config/usage_help.go
+++ b/config/usage_help.go
@@ -19,5 +19,6 @@ func UsageHelp() string {
 		"    -o, --out FILE      specify target FILE to write results to\n"+
 		"    -e, --endless       continuously repeat content of FILE\n"+
 		"                        (needs to be stopped with Ctrl+C)\n"+
+		"    -c, --color         enable colored output of status codes\n"+
 		"        --help          show this usage text", DEFAULT_HOST, DEFAULT_NUMBER_OF_ROUTINES)
 }

--- a/files/result_writer.go
+++ b/files/result_writer.go
@@ -2,17 +2,23 @@ package files
 
 import (
 	"fmt"
+	"github.com/christophgockel/goony/format"
 	"github.com/christophgockel/goony/request"
 	"io"
 )
 
-func Print(result request.Result, output io.Writer) {
-	startDate := result.StartTime.Format("2006-01-02")
-	startTime := result.StartTime.Format("15:04:05.000000000")
-	endDate := result.EndTime.Format("2006-01-02")
-	endTime := result.EndTime.Format("15:04:05.000000000")
-
-	line := fmt.Sprintf("%s,%s,%s,%s,%d,%d,%s,%s,%s\n", result.Status, startDate, startTime, result.Url, result.HttpStatus, result.Nanoseconds, endDate, endTime, result.StatusMessage)
+func Print(result request.Result, output io.Writer, formatter format.Formatter) {
+	line := fmt.Sprintf(
+		"%s,%s,%s,%s,%s,%d,%s,%s,%s\n",
+		formatter.Status(result.Status),
+		formatter.Date(result.StartTime),
+		formatter.Time(result.StartTime),
+		result.Url,
+		formatter.HttpStatus(result.HttpStatus),
+		result.Nanoseconds,
+		formatter.Date(result.EndTime),
+		formatter.Time(result.EndTime),
+		result.StatusMessage)
 
 	io.WriteString(output, line)
 }

--- a/files/result_writer.go
+++ b/files/result_writer.go
@@ -1,24 +1,13 @@
 package files
 
 import (
-	"fmt"
 	"github.com/christophgockel/goony/format"
 	"github.com/christophgockel/goony/request"
 	"io"
 )
 
-func Print(result request.Result, output io.Writer, formatter format.Formatter) {
-	line := fmt.Sprintf(
-		"%s,%s,%s,%s,%s,%d,%s,%s,%s\n",
-		formatter.Status(result.Status),
-		formatter.Date(result.StartTime),
-		formatter.Time(result.StartTime),
-		result.Url,
-		formatter.HttpStatus(result.HttpStatus),
-		result.Nanoseconds,
-		formatter.Date(result.EndTime),
-		formatter.Time(result.EndTime),
-		result.StatusMessage)
+func Write(result request.Result, output io.Writer, formatter format.Formatter) {
+	line := format.ResultLine(result, formatter)
 
 	io.WriteString(output, line)
 }

--- a/files/result_writer_test.go
+++ b/files/result_writer_test.go
@@ -3,15 +3,23 @@ package files_test
 import (
 	"bytes"
 	"github.com/christophgockel/goony/files"
+	"github.com/christophgockel/goony/format"
 	"github.com/christophgockel/goony/request"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"strconv"
 	"time"
 )
 
 var _ = Describe("Result writer", func() {
-	It("prints a Result structure as a line of CSV", func() {
-		result := request.Result{
+	var successResult request.Result
+	var failureResult request.Result
+	var output *bytes.Buffer
+
+	BeforeEach(func() {
+		output = new(bytes.Buffer)
+
+		successResult = request.Result{
 			Status:        request.SUCCESS,
 			StartTime:     time.Date(2015, 11, 13, 15, 06, 01, 123456789, time.Local),
 			Url:           "http://host/route/endpoint",
@@ -21,10 +29,46 @@ var _ = Describe("Result writer", func() {
 			StatusMessage: "",
 		}
 
-		output := new(bytes.Buffer)
+		failureResult = request.Result{
+			Status:        request.FAILURE,
+			StartTime:     time.Date(2015, 11, 13, 15, 06, 01, 123456789, time.Local),
+			Url:           "http://host/route/endpoint",
+			HttpStatus:    0,
+			Nanoseconds:   1522643,
+			EndTime:       time.Date(2015, 11, 13, 15, 06, 02, 123456789, time.Local),
+			StatusMessage: "the failure message",
+		}
+	})
 
-		files.Print(result, output)
+	It("prints a Result structure as a line of CSV", func() {
+		files.Print(successResult, output, format.NoFormatter{})
 
 		Expect(output.String()).To(Equal("S,2015-11-13,15:06:01.123456789,http://host/route/endpoint,200,1522643,2015-11-13,15:06:02.123456789,\n"))
 	})
+
+	It("prints a failure Result as a CSV line", func() {
+		files.Print(failureResult, output, format.NoFormatter{})
+
+		Expect(output.String()).To(Equal("F,2015-11-13,15:06:01.123456789,http://host/route/endpoint,0,1522643,2015-11-13,15:06:02.123456789,the failure message\n"))
+	})
+
+	Context("Formatted Results", func() {
+		It("prints results formatted", func() {
+			files.Print(successResult, output, DummyFormatter{})
+
+			Expect(output.String()).To(Equal("[S],2015-11-13,15:06:01.123456789,http://host/route/endpoint,<200>,1522643,2015-11-13,15:06:02.123456789,\n"))
+		})
+	})
 })
+
+type DummyFormatter struct {
+	format.NoFormatter
+}
+
+func (formatter DummyFormatter) Status(status request.Status) string {
+	return "[" + status.String() + "]"
+}
+
+func (formatter DummyFormatter) HttpStatus(status int) string {
+	return "<" + strconv.Itoa(status) + ">"
+}

--- a/files/result_writer_test.go
+++ b/files/result_writer_test.go
@@ -7,19 +7,14 @@ import (
 	"github.com/christophgockel/goony/request"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"strconv"
 	"time"
 )
 
-var _ = Describe("Result writer", func() {
-	var successResult request.Result
-	var failureResult request.Result
-	var output *bytes.Buffer
+var _ = Describe("Writing of results", func() {
+	It("writes results to file", func() {
+		outputFile := new(bytes.Buffer)
 
-	BeforeEach(func() {
-		output = new(bytes.Buffer)
-
-		successResult = request.Result{
+		result := request.Result{
 			Status:        request.SUCCESS,
 			StartTime:     time.Date(2015, 11, 13, 15, 06, 01, 123456789, time.Local),
 			Url:           "http://host/route/endpoint",
@@ -29,46 +24,8 @@ var _ = Describe("Result writer", func() {
 			StatusMessage: "",
 		}
 
-		failureResult = request.Result{
-			Status:        request.FAILURE,
-			StartTime:     time.Date(2015, 11, 13, 15, 06, 01, 123456789, time.Local),
-			Url:           "http://host/route/endpoint",
-			HttpStatus:    0,
-			Nanoseconds:   1522643,
-			EndTime:       time.Date(2015, 11, 13, 15, 06, 02, 123456789, time.Local),
-			StatusMessage: "the failure message",
-		}
-	})
+		files.Write(result, outputFile, format.NoFormatter{})
 
-	It("prints a Result structure as a line of CSV", func() {
-		files.Print(successResult, output, format.NoFormatter{})
-
-		Expect(output.String()).To(Equal("S,2015-11-13,15:06:01.123456789,http://host/route/endpoint,200,1522643,2015-11-13,15:06:02.123456789,\n"))
-	})
-
-	It("prints a failure Result as a CSV line", func() {
-		files.Print(failureResult, output, format.NoFormatter{})
-
-		Expect(output.String()).To(Equal("F,2015-11-13,15:06:01.123456789,http://host/route/endpoint,0,1522643,2015-11-13,15:06:02.123456789,the failure message\n"))
-	})
-
-	Context("Formatted Results", func() {
-		It("prints results formatted", func() {
-			files.Print(successResult, output, DummyFormatter{})
-
-			Expect(output.String()).To(Equal("[S],2015-11-13,15:06:01.123456789,http://host/route/endpoint,<200>,1522643,2015-11-13,15:06:02.123456789,\n"))
-		})
+		Expect(outputFile.String()).To(Equal("S,2015-11-13,15:06:01.123456789,http://host/route/endpoint,200,1522643,2015-11-13,15:06:02.123456789,\n"))
 	})
 })
-
-type DummyFormatter struct {
-	format.NoFormatter
-}
-
-func (formatter DummyFormatter) Status(status request.Status) string {
-	return "[" + status.String() + "]"
-}
-
-func (formatter DummyFormatter) HttpStatus(status int) string {
-	return "<" + strconv.Itoa(status) + ">"
-}

--- a/format/colored_formatter.go
+++ b/format/colored_formatter.go
@@ -1,0 +1,33 @@
+package format
+
+import (
+	"github.com/christophgockel/goony/request"
+	"strconv"
+)
+
+type ColoredFormatter struct {
+	NoFormatter
+}
+
+func (formatter ColoredFormatter) Status(status request.Status) string {
+	if status == request.SUCCESS {
+		return Success(status.String())
+	} else {
+		return Error(status.String())
+	}
+}
+
+func (formatter ColoredFormatter) HttpStatus(status int) string {
+	if status == 0 || status >= 400 {
+		return Error(strconv.Itoa(status))
+	}
+	return Success(strconv.Itoa(status))
+}
+
+func Success(value string) string {
+	return "\x1b[32m" + value + "\x1b[0m"
+}
+
+func Error(value string) string {
+	return "\x1b[31m" + value + "\x1b[0m"
+}

--- a/format/colored_formatter_test.go
+++ b/format/colored_formatter_test.go
@@ -1,0 +1,38 @@
+package format_test
+
+import (
+	"github.com/christophgockel/goony/format"
+	"github.com/christophgockel/goony/request"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ColoredFormatter", func() {
+	var formatter format.Formatter
+
+	BeforeEach(func() {
+		formatter = format.ColoredFormatter{}
+	})
+
+	It("colorises success status", func() {
+		success := request.SUCCESS
+		Expect(formatter.Status(success)).To(Equal(format.Success(success.String())))
+	})
+
+	It("colorises failure status", func() {
+		failure := request.FAILURE
+		Expect(formatter.Status(failure)).To(Equal(format.Error(failure.String())))
+	})
+
+	It("colorises successful HTTP statuses", func() {
+		Expect(formatter.HttpStatus(100)).To(Equal(format.Success("100")))
+		Expect(formatter.HttpStatus(200)).To(Equal(format.Success("200")))
+		Expect(formatter.HttpStatus(308)).To(Equal(format.Success("308")))
+	})
+
+	It("colorises unsuccessful HTTP statuses", func() {
+		Expect(formatter.HttpStatus(400)).To(Equal(format.Error("400")))
+		Expect(formatter.HttpStatus(500)).To(Equal(format.Error("500")))
+		Expect(formatter.HttpStatus(0)).To(Equal(format.Error("0")))
+	})
+})

--- a/format/format_suite_test.go
+++ b/format/format_suite_test.go
@@ -1,0 +1,13 @@
+package format_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestFiles(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Formatting Suite")
+}

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -1,0 +1,13 @@
+package format
+
+import (
+	"github.com/christophgockel/goony/request"
+	"time"
+)
+
+type Formatter interface {
+	Status(request.Status) string
+	HttpStatus(int) string
+	Date(time.Time) string
+	Time(time.Time) string
+}

--- a/format/no_formatter.go
+++ b/format/no_formatter.go
@@ -1,0 +1,23 @@
+package format
+
+import (
+	"github.com/christophgockel/goony/request"
+	"strconv"
+	"time"
+)
+
+type NoFormatter struct{}
+
+func (formatter NoFormatter) Status(status request.Status) string {
+	return status.String()
+}
+func (formatter NoFormatter) HttpStatus(status int) string {
+	return strconv.Itoa(status)
+}
+func (formatter NoFormatter) Date(date time.Time) string {
+	return date.Format("2006-01-02")
+}
+
+func (formatter NoFormatter) Time(time time.Time) string {
+	return time.Format("15:04:05.000000000")
+}

--- a/format/no_formatter_test.go
+++ b/format/no_formatter_test.go
@@ -1,0 +1,44 @@
+package format_test
+
+import (
+	"github.com/christophgockel/goony/format"
+	"github.com/christophgockel/goony/request"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"time"
+)
+
+var _ = Describe("NoFormatter", func() {
+	var formatter format.Formatter
+
+	BeforeEach(func() {
+		formatter = format.NoFormatter{}
+	})
+
+	It("formats successful request status", func() {
+		success := request.SUCCESS
+		Expect(formatter.Status(success)).To(Equal(success.String()))
+	})
+
+	It("formats successful request status", func() {
+		failure := request.FAILURE
+		Expect(formatter.Status(failure)).To(Equal(failure.String()))
+	})
+
+	It("formats HTTP status", func() {
+		Expect(formatter.HttpStatus(0)).To(Equal("0"))
+		Expect(formatter.HttpStatus(200)).To(Equal("200"))
+	})
+
+	It("formats dates", func() {
+		date := time.Date(2016, 1, 23, 0, 0, 0, 0, time.Local)
+
+		Expect(formatter.Date(date)).To(Equal("2016-01-23"))
+	})
+
+	It("formats times", func() {
+		time := time.Date(0, 0, 0, 16, 20, 42, 123456789, time.Local)
+
+		Expect(formatter.Time(time)).To(Equal("16:20:42.123456789"))
+	})
+})

--- a/format/result_line.go
+++ b/format/result_line.go
@@ -1,0 +1,20 @@
+package format
+
+import (
+	"fmt"
+	"github.com/christophgockel/goony/request"
+)
+
+func ResultLine(result request.Result, formatter Formatter) string {
+	return fmt.Sprintf(
+		"%s,%s,%s,%s,%s,%d,%s,%s,%s\n",
+		formatter.Status(result.Status),
+		formatter.Date(result.StartTime),
+		formatter.Time(result.StartTime),
+		result.Url,
+		formatter.HttpStatus(result.HttpStatus),
+		result.Nanoseconds,
+		formatter.Date(result.EndTime),
+		formatter.Time(result.EndTime),
+		result.StatusMessage)
+}

--- a/format/result_line_test.go
+++ b/format/result_line_test.go
@@ -1,0 +1,69 @@
+package format_test
+
+import (
+	"github.com/christophgockel/goony/format"
+	"github.com/christophgockel/goony/request"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"strconv"
+	"time"
+)
+
+var _ = Describe("ResultLine", func() {
+	var successResult request.Result
+	var failureResult request.Result
+
+	BeforeEach(func() {
+		successResult = request.Result{
+			Status:        request.SUCCESS,
+			StartTime:     time.Date(2015, 11, 13, 15, 06, 01, 123456789, time.Local),
+			Url:           "http://host/route/endpoint",
+			HttpStatus:    200,
+			Nanoseconds:   1522643,
+			EndTime:       time.Date(2015, 11, 13, 15, 06, 02, 123456789, time.Local),
+			StatusMessage: "",
+		}
+
+		failureResult = request.Result{
+			Status:        request.FAILURE,
+			StartTime:     time.Date(2015, 11, 13, 15, 06, 01, 123456789, time.Local),
+			Url:           "http://host/route/endpoint",
+			HttpStatus:    0,
+			Nanoseconds:   1522643,
+			EndTime:       time.Date(2015, 11, 13, 15, 06, 02, 123456789, time.Local),
+			StatusMessage: "the failure message",
+		}
+	})
+
+	It("formats a sucessful result into a line of comma separated values", func() {
+		line := format.ResultLine(successResult, format.NoFormatter{})
+
+		Expect(line).To(Equal("S,2015-11-13,15:06:01.123456789,http://host/route/endpoint,200,1522643,2015-11-13,15:06:02.123456789,\n"))
+	})
+
+	It("formats a failed result into a line of comma separated values", func() {
+		line := format.ResultLine(failureResult, format.NoFormatter{})
+
+		Expect(line).To(Equal("F,2015-11-13,15:06:01.123456789,http://host/route/endpoint,0,1522643,2015-11-13,15:06:02.123456789,the failure message\n"))
+	})
+
+	Context("Formatted Results", func() {
+		It("prints results formatted", func() {
+			line := format.ResultLine(successResult, DummyFormatter{})
+
+			Expect(line).To(Equal("[S],2015-11-13,15:06:01.123456789,http://host/route/endpoint,<200>,1522643,2015-11-13,15:06:02.123456789,\n"))
+		})
+	})
+})
+
+type DummyFormatter struct {
+	format.NoFormatter
+}
+
+func (formatter DummyFormatter) Status(status request.Status) string {
+	return "[" + status.String() + "]"
+}
+
+func (formatter DummyFormatter) HttpStatus(status int) string {
+	return "<" + strconv.Itoa(status) + ">"
+}

--- a/goony.go
+++ b/goony.go
@@ -54,7 +54,7 @@ func main() {
 }
 
 func options() config.Options {
-	options, err := config.Parse(os.Args[1:]...)
+	options, err := config.ParseAndCheck(os.Args[1:]...)
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/goony.go
+++ b/goony.go
@@ -40,7 +40,7 @@ func main() {
 		formatter := formatter(options.UseColors)
 
 		for result := range resultsChannel {
-			files.Print(result, outputFile, formatter)
+			files.Write(result, outputFile, formatter)
 		}
 		done <- true
 	}()

--- a/goony.go
+++ b/goony.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/christophgockel/goony/config"
 	"github.com/christophgockel/goony/files"
+	"github.com/christophgockel/goony/format"
 	"github.com/christophgockel/goony/request"
 	"github.com/christophgockel/goony/signals"
 	"net/http"
@@ -36,8 +37,10 @@ func main() {
 	}
 
 	go func() {
+		formatter := formatter(options.UseColors)
+
 		for result := range resultsChannel {
-			files.Print(result, outputFile)
+			files.Print(result, outputFile, formatter)
 		}
 		done <- true
 	}()
@@ -108,4 +111,12 @@ func catchCtrlC(output chan bool) {
 	signal.Notify(signalChannel, os.Interrupt)
 
 	go signals.WaitForSignal(signalChannel, output)
+}
+
+func formatter(useColors bool) format.Formatter {
+	if useColors {
+		return format.ColoredFormatter{}
+	} else {
+		return format.NoFormatter{}
+	}
 }


### PR DESCRIPTION
Adds `--color` and `-c` as a command line flag to enable colored output of status flags.
Uses ANSI escape codes which makes unlikely to work with Windows, though.
